### PR TITLE
[Preview] Re-center the crop window on mouse click.

### DIFF
--- a/rtgui/previewwindow.cc
+++ b/rtgui/previewwindow.cc
@@ -253,6 +253,9 @@ bool PreviewWindow::on_button_press_event (GdkEventButton* event)
         if (!isMoving) {
             isMoving = true;
 
+            // center the crop window to the mouse position
+            mainCropWin->remoteMove((event->x - x - 0.5 * w) / zoom, (event->y - y - 0.5 * h) / zoom);
+
             press_x = event->x;
             press_y = event->y;
 


### PR DESCRIPTION
- Single click on preview image can move the image in crow window to that position instantly
- Click and drag also works
I believe this is what most RAW developing programs do, LR for instance.

![20250128104430_rec_](https://github.com/user-attachments/assets/fb566979-2638-469c-b59b-72ec2877bcb5)
