### PR TITLE
[BugFix] Quick zoom out & zoom in makes zoom center to image center.

### DIFF
--- a/rtgui/crophandler.cc
+++ b/rtgui/crophandler.cc
@@ -214,8 +214,9 @@ void CropHandler::setZoom (int z, int centerx, int centery)
     }
 
     int oldZoom = zoom;
-    float oldScale = zoom >= 1000 ? float(zoom / 1000) : 10.f / float(zoom);
-    float newScale = z >= 1000 ? float(z / 1000) : 10.f / float(z);
+    // TODO(zoulu): Find better way to avoid hard coding 1000 as the threshold
+    float oldScale = zoom >= 1000 ? float(zoom) / 1000.0f : 10.f / float(zoom);
+    float newScale = z >= 1000 ? float(z) / 1000.0f : 10.f / float(z);
 
     int oldcax = cax;
     int oldcay = cay;

--- a/rtgui/cropwindow.cc
+++ b/rtgui/cropwindow.cc
@@ -118,7 +118,9 @@ void CropWindow::initZoomSteps()
     // zoomSteps.push_back(ZoomStep("  6%", 1.0/15.0, 150, true));
     // zoomSteps.push_back(ZoomStep("  8%", 1.0/12.0, 120, true));
     char lbl[64];
-    for (int s = 1000; s >= 11; --s) {
+    // NOTE(zoulu): 1000 is the watershed for zoomed in and zoomed out, >=1000 (inclusive) indicates zoomed in.
+    // TODO(zoulu): avoid magic numbers, it's used widely among multiple files.
+    for (int s = 1000 - 1; s >= 10; --s) {
         float z = 10./float(s);
         sprintf(lbl, "% 2d%%", int(z * 100));
         bool is_major = (s == s/10 * 10);
@@ -2006,7 +2008,7 @@ void CropWindow::zoomIn (bool toCursor, int cursorX, int cursorY)
             }
 
             zoomVersion = exposeVersion;
-        } else if (zoomVersion != exposeVersion) {
+        } else {
             screenCoordToImage(xpos + imgX + imgW / 2, ypos + imgY + imgH / 2, x, y);
 
             if (cropHandler.cropParams.enabled) {
@@ -2056,8 +2058,8 @@ void CropWindow::zoomOut (bool toCursor, int cursorX, int cursorY)
     }
 
     zoomVersion = exposeVersion;
-    int z = cropZoom - 1;
-    while (z >= 0 && !zoomSteps[z].is_major) {
+    int z = std::max(cropZoom - 1, 0);
+    while (z > 0 && !zoomSteps[z].is_major) {
         --z;
     }
     changeZoom (z, true, x, y);
@@ -2240,11 +2242,10 @@ void CropWindow::updateHoveredPicker (rtengine::Coord *imgPos)
 }
 void CropWindow::changeZoom (int zoom, bool notify, int centerx, int centery, bool needsRedraw)
 {
-
     if (zoom < 0) {
         zoom = 0;
-    } else if (zoom > int(zoomSteps.size())-1) {
-        zoom = int(zoomSteps.size())-1;
+    } else if (zoom >= int(zoomSteps.size())) {
+        zoom = int(zoomSteps.size()) - 1;
     }
 
     cropZoom = zoom;


### PR DESCRIPTION
Reproduce method: quickly zoom out then zoom in (using keyboard shortcut -/+), you'll notice the zoom center reset to image center.

This bug annoys me a lot, as I zoom in and out a lot.

The reason is as follows:
1. in `zoomOut()`, we set `zoomVersion = exposeVersion`, then schedule a `redraw()`
2. The `on_draw()` method made `exposeVersion++`
3. in `zoomIn()`, we check when `zoomVersion == exposeVersion` the zoom center is never calculated

However, redraw is not instantaneous, it's an async callback. If we try to zoom in before redraw is done, we are in a place where `zoomVersion == exposeVersion` is `true`, so the zooming center `x, y` will not be calculated, keeps it initail value `-1, -1`, in effect makes the zoom center jump back from whatever position in the photo to the center.

**I actually think maybe we could ditch `zoomVersion` and `exposeVersion` all together**

**Before fix**👇
![20250128150226_rec_](https://github.com/user-attachments/assets/d0d6fc6a-1810-4085-91a8-08019f29f114)

**After the  fix**👇
![20250128145710_rec_](https://github.com/user-attachments/assets/893fccac-205a-493d-b8d9-4288729797ef)


