### PR TITLE
Fix compile on arm windows

### DIFF
--- a/rtgui/CMakeLists.txt
+++ b/rtgui/CMakeLists.txt
@@ -256,7 +256,7 @@ else()
 endif()
 
 # Excluding libatomic needed by Clang/FreeBSD, #3636
-if(OPENMP_FOUND AND NOT APPLE AND NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
+if(OPENMP_FOUND AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(EXTRA_LIB_RTGUI ${EXTRA_LIB_RTGUI} "atomic")
 endif()
 


### PR DESCRIPTION
`libatomic` is bundled with gcc only, so linking with it is only necessary if the compiler is GNU gcc (clang has it's own built-in atomic mechanism, no need to link with atomic)

As libatomic is so common in Linux distros, so the bug does no harm. But I'm running a Windows on Arm, `clang` is the only compiler available at the time, gcc and libatomic are not in the `msys2` default repository, so the original version won't compile I my case, thus the fix.

