### PR TITLE
[BugFix] Check default dir before add existing directory to 'Places'.

### DIFF
--- a/rtgui/placesbrowser.h
+++ b/rtgui/placesbrowser.h
@@ -28,12 +28,19 @@ public:
     typedef sigc::slot<void, const Glib::ustring&> DirSelectionSlot;
 
 private:
+    enum class PlaceType : uint8_t {
+      MOUNT,
+      VOLUME,
+      DRIVE,
+      DEFAULT_DIR_OR_SESSION,
+      FAVARITE_DIR
+    };
     class PlacesColumns: public Gtk::TreeModel::ColumnRecord {
     public:
         Gtk::TreeModelColumn<Glib::RefPtr<Gio::Icon>> icon;
         Gtk::TreeModelColumn<Glib::ustring> label;
         Gtk::TreeModelColumn<Glib::ustring> root;
-        Gtk::TreeModelColumn<int> type;
+        Gtk::TreeModelColumn<PlaceType> type;
         Gtk::TreeModelColumn<bool> rowSeparator;
         PlacesColumns()
         {
@@ -57,6 +64,10 @@ private:
     Glib::RefPtr<Gio::FileMonitor> session_monitor_;
 
     void on_session_changed(const Glib::RefPtr<Gio::File>& file, const Glib::RefPtr<Gio::File>& other_file, Gio::FileMonitorEvent event_type);
+
+    void SetRow(Gtk::TreeModel::Row row, Glib::RefPtr<Gio::Icon> icon,
+                Glib::ustring label, Glib::ustring root, PlaceType type,
+                bool rowSeparator);
     
 public:
 


### PR DESCRIPTION
1. Bugfix: Adding a default (a.k.a Pictures and Documents, volumes, drive, mounts) directory to 'Places' via 'add button' will result in two items shown in 'Places', and click on either one always selects the default directory. Unable to remove the added favorite directory unless manually edit the options file
2. Replace `int` type with `enum`, make code more clear
3. Added a convenient helper function `SetRow()` to avoid code repeat 

![image](https://github.com/user-attachments/assets/4f4d928a-050f-441c-b1f0-39a75e819c59)
