### PR TITLE
Read GDK_BACKEND from environment instead of forcing X11

### DIFF
--- a/tools/linux/bundle_ART.py
+++ b/tools/linux/bundle_ART.py
@@ -331,7 +331,7 @@ export GTK_IM_MODULE_FILE="$t/gtk.immodules"
 export GIO_MODULE_DIR="$d/lib/gio/modules"
 export FONTCONFIG_FILE="$d/fonts.conf"
 export ART_EXIFTOOL_BASE_DIR="$d/lib/exiftool"
-export GDK_BACKEND=x11
+GDK_BACKEND="${GDK_BACKEND:-wayland,x11}"
 """)
         if not opts.debug:
             out.write('"$d/.ART.bin" "$@"\n')


### PR DESCRIPTION
Closes #401 

Use GDK_BACKEND from environment instead of forcing X11.

In the case that GDK_BACKEND is unavailable, it defaults to "wayland,x11" which will use wayland when available, and fall back to x11 otherwise.