### PR TITLE
Fixing bug with display of crops on exif rotated thumbnails

### DIFF
--- a/rtgui/thumbnail.cc
+++ b/rtgui/thumbnail.cc
@@ -664,12 +664,9 @@ void Thumbnail::getOriginalSize(int &w, int &h, bool consider_coarse)
     w = cfs.width;
     h = cfs.height;
     if (consider_coarse) {
-        int rotate = 0;
+        int rotate = infoFromImage(fname);
         if (pparamsValid) {
-            rotate = pparams.master.coarse.rotate;
-        }
-        if (rotate == 0) {
-            rotate = infoFromImage(fname);
+            rotate = (rotate + pparams.master.coarse.rotate) % 360;
         }
         if (rotate == 90 || rotate == 270) {
             std::swap(w, h);


### PR DESCRIPTION
If an image is rotated in the exif data the crop preview in the file browser will look wrong. This is due to FileBrowserEntry::customBackBufferUpdate calling thumbnail->getOriginalSize, which currently only swaps the width and height if there is coarse rotation data.

This updates Thumbnail::getOriginalSize to combine the exif rotation and any coarse rotation.