### PR TITLE
Adding support for tiff files with palettes

### DIFF
--- a/rtengine/imageio.cc
+++ b/rtengine/imageio.cc
@@ -788,7 +788,7 @@ int ImageIO::loadTIFF(const Glib::ustring &fname)
         TIFFSetField(in, TIFFTAG_SGILOGDATAFMT, SGILOGDATAFMT_FLOAT);
     }
 
-     /*
+    /*
      * We could use the min/max values set in TIFFTAG_SMINSAMPLEVALUE and
      * TIFFTAG_SMAXSAMPLEVALUE, but for now, we normalize the image to the
      * effective minimum and maximum values


### PR DESCRIPTION
I have a couple of tiff files of newspaper scans that weren't showing up. After digging around in the tiff reading code it turns out they used palettes. This adds support for loading them. You can use [this file](https://gitlab.com/libtiff/libtiff-pics/-/blob/master/jello.tif) to test it.