### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/rtengine/dcraw.c
+++ b/rtengine/dcraw.c
@@ -7724,6 +7724,8 @@ void CLASS parse_qt(int end)
         save = ftell(ifp);
         if ((size = get4()) < 8)
             return;
+        if ((int)size < 0) return; // 2+GB is too much
+        if (save + size < save) return; // 32bit overflow
         fread(tag, 4, 1, ifp);
         if (!memcmp(tag, "moov", 4) || !memcmp(tag, "udta", 4) ||
             !memcmp(tag, "CNTH", 4))


### PR DESCRIPTION
### Summary
Our tool detected a potential vulnerability in rtengine/dcraw.c which was cloned from LibRaw/LibRaw but did not receive the security patch applied. The original issue was reported and fixed under https://nvd.nist.gov/vuln/detail/cve-2018-5815.

### Proposed Fix
Apply the same patch as the one in LibRaw/LibRaw to eliminate the vulnerability.

### Reference
https://nvd.nist.gov/vuln/detail/cve-2018-5815
https://github.com/LibRaw/LibRaw/commit/1334647862b0c90b2e8cb2f668e66627d9517b17