### PR TITLE
KLT Files duplicated, WITH_SYSTEM_KLT not respected

### DIFF
--- a/rtengine/CMakeLists.txt
+++ b/rtengine/CMakeLists.txt
@@ -96,16 +96,6 @@ set(RTENGINESOURCEFILES
     ipsharpen.cc
     iptransform.cc
     rtjpeg.cc
-    klt/convolve.cc
-    klt/error.cc
-    klt/klt.cc
-    klt/klt_util.cc
-    klt/pnmio.cc
-    klt/pyramid.cc
-    klt/selectGoodFeatures.cc
-    klt/storeFeatures.cc
-    klt/trackFeatures.cc
-    klt/writeFeatures.cc
     labimage.cc
     lcp.cc
     lmmse_demosaic.cc


### PR DESCRIPTION
The KLT files are in the RTENGINESOURCEFILES by default, this breaks the ability to use WITH_SYSTEM_KLT.
