### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -3867,7 +3867,7 @@ void CLASS foveon_huff (ushort *huff)
 void CLASS foveon_dp_load_raw()
 {
   unsigned c, roff[4], row, col, diff;
-  ushort huff[512], vpred[2][2], hpred[2];
+  ushort huff[1024], vpred[2][2], hpred[2];
 
   fseek (ifp, 8, SEEK_CUR);
   foveon_huff (huff);
@@ -3891,12 +3891,16 @@ void CLASS foveon_dp_load_raw()
 void CLASS foveon_load_camf()
 {
   unsigned type, wide, high, i, j, row, col, diff;
-  ushort huff[258], vpred[2][2] = {{512,512},{512,512}}, hpred[2];
+  ushort huff[1024], vpred[2][2] = {{512,512},{512,512}}, hpred[2];
 
   fseek (ifp, meta_offset, SEEK_SET);
   type = get4();  get4();  get4();
   wide = get4();
   high = get4();
+#ifdef LIBRAW_LIBRARY_BUILD
+  if(wide>32767 || high > 32767 || wide*high > 20000000)
+     throw LIBRAW_EXCEPTION_IO_CORRUPT;
+#endif
   if (type == 2) {
     fread (meta_data, 1, meta_length, ifp);
     for (i=0; i < meta_length; i++) {


### PR DESCRIPTION
This PR fixes a potential security vulnerability in rtengine/dcraw.cc that was cloned from https://github.com/LibRaw/LibRaw-demosaic-pack-GPL2 but did not receive the security patch.

### Details:
Affected File: rtengine/dcraw.cc
Original Fix: https://github.com/LibRaw/LibRaw-demosaic-pack-GPL2/commit/194f592e205990ea8fce72b6c571c14350aca716

### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.
### References:
- https://github.com/LibRaw/LibRaw-demosaic-pack-GPL2/commit/194f592e205990ea8fce72b6c571c14350aca716
- https://nvd.nist.gov/vuln/detail/CVE-2017-6890

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.
